### PR TITLE
Updating metadata call to determine AZ

### DIFF
--- a/startup-cdk.sh
+++ b/startup-cdk.sh
@@ -68,12 +68,12 @@ if [[ "${orchestrator}" == 'kubernetes' ]]; then
 fi 
 
 if [[ ${orchestrator} == 'unknown' ]]; then
-  zone=$(curl -m2 -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
+  zone=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
 fi 
 
 # Am I on ec2 instances?
 if [[ ${zone} == "unknown" ]]; then
-  zone=$(curl -m2 -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
+  zone=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
 fi
 
 # Still no luck? Perhaps we're running fargate!

--- a/startup.sh
+++ b/startup.sh
@@ -68,12 +68,12 @@ if [[ "${orchestrator}" == 'kubernetes' ]]; then
 fi 
 
 if [[ ${orchestrator} == 'unknown' ]]; then
-  zone=$(curl -m2 -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
+  zone=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
 fi 
 
 # Am I on ec2 instances?
 if [[ ${zone} == "unknown" ]]; then
-  zone=$(curl -m2 -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
+  zone=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
 fi
 
 # Still no luck? Perhaps we're running fargate!


### PR DESCRIPTION
*Issue #, if available:*
The code to determine which Availability Zone (AZ) the node running this pod is in had not worked on a new deployment (Feb 2025).  Troubleshooting indicated that the script was unable to determine the AZ.  This update provides a method using IMDSv2

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-retrieval-examples

*Description of changes:*
```
# Am I on ec2 instances?
if [[ ${zone} == "unknown" ]]; then
-  # zone=$(curl -m2 -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
+  zone=$(TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.availabilityZone' | grep -o .$)
fi
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
